### PR TITLE
Update website title from 'Document' to 'Reteena'

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0"
           name="viewport">
     <meta content="ie=edge" http-equiv="X-UA-Compatible">
-    <title>Document</title>
+    <title>Reteena</title>
     <link href="./style.css" rel="stylesheet">
 </head>
 <body>


### PR DESCRIPTION
This PR updates the website title that appears in the browser tab from the generic "Document" to "Reteena".

### Changes:
- Changed the text within the `<title>` tag from "Document" to "Reteena"

This simple change improves branding consistency and provides better context when users have multiple tabs open. It also enhances the professionalism of the site by showing the actual company name in the browser tab instead of the default placeholder.