### PR TITLE
Styling updates: reduce gaps and add lines between team members

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,14 +41,19 @@
         }
         
         .team-members {
-            margin-top: 30px;
+            margin-top: 10px; /* Reduced from 30px */
             width: 100%;
         }
         .member {
             display: flex;
             justify-content: space-between;
-            margin-bottom: 10px; /* This adds vertical spacing between names */
+            margin-bottom: 0; /* Removed bottom margin */
             width: 100%;
+            padding: 8px 0; /* Added padding instead of margin */
+            border-bottom: 1px solid #eee; /* Added thin line between names */
+        }
+        .member:first-child {
+            padding-top: 0; /* Remove padding from first member */
         }
         .member span:first-child {
             text-align: left;
@@ -63,7 +68,7 @@
         }
         .team-description {
             margin-top: 10px;
-            margin-bottom: 20px;
+            margin-bottom: 10px; /* Reduced from 20px to create less gap */
             line-height: 1.5;
             text-align: justify;
             text-justify: inter-word;
@@ -99,8 +104,8 @@
         </h1>
         <a href="https://www.linkedin.com/company/reteena/" target="_blank">
             <svg height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-                <path d="M19 3a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2zm-.5 15.5v-5.3a3.26 3.26 0 0 0-3.26-3.26c-.85 0-1.84.52-2.32 1.3v-1.11h-2.79v8.37h2.79v-4.93c0-.77.62-1.4 1.39-1.4a1.4 1.4 0 0 1 1.4 1.4v4.93zM6.88 8.56a1.68 1.68 0 0 0 1.68-1.68c0-.93-.75-1.69-1.68-1.69a1.69 1.69 0 0 0-1.69 1.69c0 .93.76 1.68 1.69 1.68m1.39 9.94v-8.37H5.5v8.37z"
-                      fill="currentColor"/>
+                    <path d="M19 3a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2zm-.5 15.5v-5.3a3.26 3.26 0 0 0-3.26-3.26c-.85 0-1.84.52-2.32 1.3v-1.11h-2.79v8.37h2.79v-4.93c0-.77.62-1.4 1.39-1.4a1.4 1.4 0 0 1 1.4 1.4v4.93zM6.88 8.56a1.68 1.68 0 0 0 1.68-1.68c0-.93-.75-1.69-1.68-1.69a1.69 1.69 0 0 0-1.69 1.69c0 .93.76 1.68 1.69 1.68m1.39 9.94v-8.37H5.5v8.37z"
+                          fill="currentColor"/>
             </svg>
         </a>
     </div>
@@ -109,12 +114,12 @@
         <p>
             We are building Low-Field MRI Resolution Image Enhancement Framework for Better Alzheimer's Diagnosis and
             the
-            <a href="https://www.linkedin.com/posts/alexyang77_introducing-remembrance-by-reteena-the-activity-7332915036396433409-bNQ6?utm_source=share&utm_medium=member_desktop&rcm=ACoAAE3UIjQBZFtlI1COnxn2N_ig4-DZEnujWtM" target="_blank" class="external-link">
+            <a href="https://www.linkedin.com/posts/alexyang77_introducing-remembrance-by-reteena-the-activity-7332915036396433409-bNQ6?utm_source=share&utm_medium=member_desktop&rcm=ACoAAE3UIjQBZFtlI1COnn2N_ig4-DZEnujWtM" target="_blank" class="external-link">
                 <span style="text-decoration: underline;">LLM-based Memory Repository for Reminiscence Therapy</span>
                 <svg xmlns="http://www.w3.org/2000/svg" height="14" viewBox="0 0 24 24" width="14" style="vertical-align: middle; margin-left: 4px;">
-                    <path d="M18 13v6a1 1 0 0 1-1 1H6a1 1 0 0 1-1-1V7a1 1 0 0 1 1-1h6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-                    <polyline points="15 3 21 3 21 9" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-                    <line x1="10" y1="14" x2="21" y2="3" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                        <path d="M18 13v6a1 1 0 0 1-1 1H6a1 1 0 0 1-1-1V7a1 1 0 0 1 1-1h6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                        <polyline points="15 3 21 3 21 9" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                        <line x1="10" y1="14" x2="21" y2="3" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
                 </svg>
             </a>
         </p>
@@ -124,10 +129,10 @@
         </p>
 
         <p>We have achieved multiple milestones: submission to <a class="strong__links"
-                                                                 href="https://solve.mit.edu/solutions/86724"
-                                                                 target="_blank">MIT
+                                                                href="https://solve.mit.edu/solutions/86724"
+                                                                target="_blank">MIT
             SOLVE</a>, presentation at <a class="strong__links"
-                                         href="https://ieeexplore.ieee.org/document/10826144" target="_blank">IEEE
+                                        href="https://ieeexplore.ieee.org/document/10826144" target="_blank">IEEE
             BigData
             2024</a>, sponsorship
             from <a class="strong__links"
@@ -141,7 +146,7 @@
         <!-- Email input system added here -->
         <div class="email-signup">
             <form id="email-form" novalidate>
-                <input type="email" id="email-input" placeholder="Enter your email">
+                 <input type="email" id="email-input" placeholder="Enter your email">
                 <button type="submit" id="email-submit">Send</button>
             </form>
             <p id="email-message" class="email-message">Please enter your email address</p>


### PR DESCRIPTION
This PR makes the following changes:

1. Reduces the vertical gap between the team description paragraph and Alex Yang's name
2. Adds very thin lines (1px light gray) between different team member names
3. Improves spacing for better readability

The changes include:
- Reduced margin-top for team-members from 30px to 10px
- Reduced margin-bottom for team-description from 20px to 10px
- Added border-bottom (1px solid #eee) to each member div
- Replaced member margin with padding for better spacing