### PR TITLE
Add dark mode toggle functionality

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,10 +28,12 @@
             margin: 0;
             padding: 0;
             color: #000000;
+            transition: background-color 0.3s ease, color 0.3s ease;
         }
         h1, h2, h3, h4, h5, h6, p, span, a, button, input, textarea, select, option, label {
             font-family: 'EB Garamond', serif !important;
             color: #000000 !important;
+            transition: color 0.3s ease;
         }
         .header h1 {
             font-family: 'EB Garamond', serif !important;
@@ -138,25 +140,107 @@
             height: 14px !important;
             display: inline-block;
         }
+        
+        /* Dark mode styles */
+        body.dark-mode {
+            background-color: #121212;
+        }
+        body.dark-mode h1, 
+        body.dark-mode h2, 
+        body.dark-mode h3, 
+        body.dark-mode h4, 
+        body.dark-mode h5, 
+        body.dark-mode h6, 
+        body.dark-mode p, 
+        body.dark-mode span, 
+        body.dark-mode a, 
+        body.dark-mode .member span, 
+        body.dark-mode .team-description,
+        body.dark-mode .footer_sub p,
+        body.dark-mode .header h1 {
+            color: #e0e0e0 !important;
+        }
+        body.dark-mode svg {
+            color: #e0e0e0 !important;
+        }
+        body.dark-mode svg path, 
+        body.dark-mode svg polyline, 
+        body.dark-mode svg line {
+            color: #e0e0e0 !important;
+        }
+        body.dark-mode #email-input {
+            background-color: #1e1e1e;
+            color: #e0e0e0 !important;
+            border-color: #333;
+        }
+        body.dark-mode #email-input::placeholder {
+            color: #999 !important;
+        }
+        body.dark-mode #email-submit {
+            background-color: #333;
+            color: #e0e0e0 !important;
+            border-color: #444;
+        }
+        body.dark-mode .member:hover {
+            background: #1e1e1e;
+        }
+        
+        /* Theme toggle button */
+        .theme-toggle {
+            display: inline-block;
+            margin-left: 16px;
+            cursor: pointer;
+        }
+        .theme-toggle svg {
+            width: 14px;
+            height: 14px;
+            vertical-align: middle;
+        }
+        .theme-toggle .sun-icon,
+        body.dark-mode .theme-toggle .moon-icon {
+            display: none;
+        }
+        .theme-toggle .moon-icon,
+        body.dark-mode .theme-toggle .sun-icon {
+            display: inline-block;
+        }
     </style>
 </head>
 <body>
 <main>
     <div class="header" data-aos="fade-down" data-aos-duration="800">
         <h1>Reteena</h1>
-        <a href="https://www.linkedin.com/company/reteena/" target="_blank" style="display: inline-block;">
-            <svg class="linkedin-icon" style="width: 14px; height: 14px;" viewBox="0 0 382 382" xml:space="preserve">
-                <path style="fill:#0077B7;" d="M347.445,0H34.555C15.471,0,0,15.471,0,34.555v312.889C0,366.529,15.471,382,34.555,382h312.889
-                C366.529,382,382,366.529,382,347.444V34.555C382,15.471,366.529,0,347.445,0z M118.207,329.844c0,5.554-4.502,10.056-10.056,10.056
-                H65.345c-5.554,0-10.056-4.502-10.056-10.056V150.403c0-5.554,4.502-10.056,10.056-10.056h42.806
-                c5.554,0,10.056,4.502,10.056,10.056V329.844z M86.748,123.432c-22.459,0-40.666-18.207-40.666-40.666S64.289,42.1,86.748,42.1
-                s40.666,18.207,40.666,40.666S109.208,123.432,86.748,123.432z M341.91,330.654c0,5.106-4.14,9.246-9.246,9.246H286.73
-                c-5.106,0-9.246-4.14-9.246-9.246v-84.168c0-12.556,3.683-55.021-32.813-55.021c-28.309,0-34.051,29.066-35.204,42.11v97.079
-                c0,5.106-4.139,9.246-9.246,9.246h-44.426c-5.106,0-9.246-4.14-9.246-9.246V149.593c0-5.106,4.14-9.246,9.246-9.246h44.426
-                c5.106,0,9.246,4.14,9.246,9.246v15.655c10.497-15.753,26.097-27.912,59.312-27.912c73.552,0,73.131,68.716,73.131,106.472
-                L341.91,330.654L341.91,330.654z"/>
-            </svg>
-        </a>
+        <div style="display: flex; align-items: center;">
+            <a href="https://www.linkedin.com/company/reteena/" target="_blank" style="display: inline-block;">
+                <svg class="linkedin-icon" style="width: 14px; height: 14px;" viewBox="0 0 382 382" xml:space="preserve">
+                    <path style="fill:#0077B7;" d="M347.445,0H34.555C15.471,0,0,15.471,0,34.555v312.889C0,366.529,15.471,382,34.555,382h312.889
+                    C366.529,382,382,366.529,382,347.444V34.555C382,15.471,366.529,0,347.445,0z M118.207,329.844c0,5.554-4.502,10.056-10.056,10.056
+                    H65.345c-5.554,0-10.056-4.502-10.056-10.056V150.403c0-5.554,4.502-10.056,10.056-10.056h42.806
+                    c5.554,0,10.056,4.502,10.056,10.056V329.844z M86.748,123.432c-22.459,0-40.666-18.207-40.666-40.666S64.289,42.1,86.748,42.1
+                    s40.666,18.207,40.666,40.666S109.208,123.432,86.748,123.432z M341.91,330.654c0,5.106-4.14,9.246-9.246,9.246H286.73
+                    c-5.106,0-9.246-4.14-9.246-9.246v-84.168c0-12.556,3.683-55.021-32.813-55.021c-28.309,0-34.051,29.066-35.204,42.11v97.079
+                    c0,5.106-4.139,9.246-9.246,9.246h-44.426c-5.106,0-9.246-4.14-9.246-9.246V149.593c0-5.106,4.14-9.246,9.246-9.246h44.426
+                    c5.106,0,9.246,4.14,9.246,9.246v15.655c10.497-15.753,26.097-27.912,59.312-27.912c73.552,0,73.131,68.716,73.131,106.472
+                    L341.91,330.654L341.91,330.654z"/>
+                </svg>
+            </a>
+            <div class="theme-toggle" id="theme-toggle">
+                <svg class="sun-icon" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <circle cx="12" cy="12" r="5"></circle>
+                    <line x1="12" y1="1" x2="12" y2="3"></line>
+                    <line x1="12" y1="21" x2="12" y2="23"></line>
+                    <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line>
+                    <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line>
+                    <line x1="1" y1="12" x2="3" y2="12"></line>
+                    <line x1="21" y1="12" x2="23" y2="12"></line>
+                    <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line>
+                    <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
+                </svg>
+                <svg class="moon-icon" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+                </svg>
+            </div>
+        </div>
     </div>
 
     <section class="introduction">
@@ -262,6 +346,24 @@
         fadeInOnScroll();
         // Run on scroll
         window.addEventListener('scroll', fadeInOnScroll);
+        
+        // Dark mode toggle functionality
+        const themeToggle = document.getElementById('theme-toggle');
+        
+        // Check for saved theme preference or default to light
+        const savedTheme = localStorage.getItem('theme') || 'light';
+        if (savedTheme === 'dark') {
+            document.body.classList.add('dark-mode');
+        }
+        
+        // Toggle theme when button is clicked
+        themeToggle.addEventListener('click', () => {
+            document.body.classList.toggle('dark-mode');
+            
+            // Save theme preference
+            const currentTheme = document.body.classList.contains('dark-mode') ? 'dark' : 'light';
+            localStorage.setItem('theme', currentTheme);
+        });
     });
 </script>
 </body>

--- a/moon.svg
+++ b/moon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+</svg>

--- a/sun.svg
+++ b/sun.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="12" cy="12" r="5"></circle>
+  <line x1="12" y1="1" x2="12" y2="3"></line>
+  <line x1="12" y1="21" x2="12" y2="23"></line>
+  <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line>
+  <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line>
+  <line x1="1" y1="12" x2="3" y2="12"></line>
+  <line x1="21" y1="12" x2="23" y2="12"></line>
+  <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line>
+  <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
+</svg>


### PR DESCRIPTION
This PR adds a dark mode toggle functionality to the Reteena Website.

Changes:
- Added dark mode toggle button next to LinkedIn icon in the header
- Added sun/moon SVG icons for the toggle button
- Implemented dark mode styling with appropriate color changes
- Added JavaScript to handle theme toggling and save user preference
- Ensures the site maintains its professional appearance in both light and dark modes

The toggle respects user preferences and saves their choice in localStorage for future visits.